### PR TITLE
uodate handler/statuses/get.go

### DIFF
--- a/app/handler/statuses/get.go
+++ b/app/handler/statuses/get.go
@@ -30,16 +30,19 @@ func (h *handler) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a := h.app.Dao.Account() // domain/repositoryの取得
+	if status != nil {
 
-	account, err := a.FindByID(ctx, status.AccountID)
+		a := h.app.Dao.Account() // domain/repositoryの取得
 
-	if err != nil {
-		httperror.InternalServerError(w, err)
-		return
+		account, err := a.FindByID(ctx, status.AccountID)
+
+		if err != nil {
+			httperror.InternalServerError(w, err)
+			return
+		}
+
+		status.Account = *account
 	}
-
-	status.Account = *account
 
 	w.Header().Set("Content-Type", "application/json")
 


### PR DESCRIPTION
GETしようとしたstatusデータがない場合、サーバ側でヌルポが起きてしまう箇所を修正
